### PR TITLE
Fix tutor dashboard stats display and add separate API calls

### DIFF
--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -86,39 +86,78 @@ const Dashboard = ({ currentUser }) => {
           hoursCompleted: statsData.hoursCompleted || 0,
         });
 
-        // Recent Activity - handle both nested and direct structures
-        const activityData = data.recentActivity || [];
-        const mappedActivity = Array.isArray(activityData)
-          ? activityData.map(a => ({
-              id: a.date || a.id || Math.random(),
-              message: a.action || a.message || 'Activity',
-              time: a.date ? new Date(a.date).toLocaleString() : '',
-              icon: 'Calendar',
-              status: a.status === 'pending' ? 'upcoming' : a.status
-            }))
-          : [];
-        setRecentActivity(mappedActivity);
+        // Fetch Recent Activity separately for tutors
+        if (currentUser.type === 'tutor') {
+          try {
+            const activityResponse = await execute(() => tutorAPI.getRecentActivity());
+            const activityData = activityResponse.data || [];
+            const mappedActivity = Array.isArray(activityData)
+              ? activityData.map(a => ({
+                  id: a.date || a.id || a._id || Math.random(),
+                  message: a.action || a.message || a.description || 'Activity',
+                  time: a.date ? new Date(a.date).toLocaleString() : '',
+                  icon: 'Calendar',
+                  status: a.status === 'pending' ? 'upcoming' : a.status
+                }))
+              : [];
+            setRecentActivity(mappedActivity);
+          } catch (activityError) {
+            console.error('Failed to load recent activity:', activityError);
+            setRecentActivity([]);
+          }
 
-        // Upcoming Lessons - handle both nested and direct structures
-        const lessonsData = data.upcomingLessons || [];
-        const mappedLessons = Array.isArray(lessonsData)
-          ? lessonsData.map(l => ({
-              id: l._id || l.id || l.date || Math.random(),
-              // For tutors, show student info; for students, show tutor info
-              otherParty: currentUser.type === 'tutor'
-                ? (l.studentId?.fullName || l.student?.fullName || 'Unknown Student')
-                : (l.tutorId?.fullName || l.tutor?.fullName || 'Unknown Tutor'),
-              tutor: currentUser.type === 'tutor'
-                ? (l.studentId?.fullName || l.student?.fullName || 'Unknown Student')
-                : (l.tutorId?.fullName || l.tutor?.fullName || 'Unknown Tutor'),
-              subject: l.subject || '',
-              duration: l.duration ? `${l.duration}h` : '',
-              time: l.scheduledDate ? new Date(l.scheduledDate).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }) : '',
-              status: l.status === 'pending' ? 'upcoming' : l.status,
-              totalCost: l.totalAmount || l.hourlyRate || 0,
-            }))
-          : [];
-        setUpcomingLessons(mappedLessons);
+          // Fetch Upcoming Lessons separately for tutors
+          try {
+            const lessonsResponse = await execute(() => tutorAPI.getUpcomingLessons());
+            const lessonsData = lessonsResponse.data || [];
+            const mappedLessons = Array.isArray(lessonsData)
+              ? lessonsData.map(l => ({
+                  id: l._id || l.id || l.date || Math.random(),
+                  // For tutors, show student info
+                  otherParty: l.studentId?.fullName || l.student?.fullName || 'Unknown Student',
+                  tutor: l.studentId?.fullName || l.student?.fullName || 'Unknown Student',
+                  subject: l.subject || '',
+                  duration: l.duration ? `${l.duration}h` : '',
+                  time: l.scheduledDate ? new Date(l.scheduledDate).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }) : '',
+                  status: l.status === 'pending' ? 'upcoming' : l.status,
+                  totalCost: l.totalAmount || l.hourlyRate || 0,
+                }))
+              : [];
+            setUpcomingLessons(mappedLessons);
+          } catch (lessonsError) {
+            console.error('Failed to load upcoming lessons:', lessonsError);
+            setUpcomingLessons([]);
+          }
+        } else {
+          // For students, use the existing logic from the main dashboard call
+          const activityData = data.recentActivity || [];
+          const mappedActivity = Array.isArray(activityData)
+            ? activityData.map(a => ({
+                id: a.date || a.id || Math.random(),
+                message: a.action || a.message || 'Activity',
+                time: a.date ? new Date(a.date).toLocaleString() : '',
+                icon: 'Calendar',
+                status: a.status === 'pending' ? 'upcoming' : a.status
+              }))
+            : [];
+          setRecentActivity(mappedActivity);
+
+          const lessonsData = data.upcomingLessons || [];
+          const mappedLessons = Array.isArray(lessonsData)
+            ? lessonsData.map(l => ({
+                id: l._id || l.id || l.date || Math.random(),
+                // For students, show tutor info
+                otherParty: l.tutorId?.fullName || l.tutor?.fullName || 'Unknown Tutor',
+                tutor: l.tutorId?.fullName || l.tutor?.fullName || 'Unknown Tutor',
+                subject: l.subject || '',
+                duration: l.duration ? `${l.duration}h` : '',
+                time: l.scheduledDate ? new Date(l.scheduledDate).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }) : '',
+                status: l.status === 'pending' ? 'upcoming' : l.status,
+                totalCost: l.totalAmount || l.hourlyRate || 0,
+              }))
+            : [];
+          setUpcomingLessons(mappedLessons);
+        }
 
         setIsLoading(false);
       } catch (error) {

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -73,16 +73,17 @@ const Dashboard = ({ currentUser }) => {
           console.warn('Using fallback dashboard data - API may not be returning data properly');
         }
 
-        // Stats
+        // Stats - handle both nested (data.stats.*) and direct (data.*) structures
+        const statsData = data.stats || data;
         setStats({
-          totalBookings: data.stats?.totalBookings || 0,
-          completedLessons: data.stats?.completedLessons || 0,
-          totalSpent: data.stats?.totalSpent || 0,
-          hoursLearned: data.stats?.hoursLearned || 0,
-          totalStudents: data.stats?.favoriteTutorsCount || data.stats?.totalStudents || 0,
-          totalEarnings: data.stats?.totalEarnings || 0,
-          averageRating: data.stats?.averageRating || 0,
-          hoursCompleted: data.stats?.hoursCompleted || 0,
+          totalBookings: statsData.totalBookings || 0,
+          completedLessons: statsData.completedLessons || 0,
+          totalSpent: statsData.totalSpent || 0,
+          hoursLearned: statsData.hoursLearned || 0,
+          totalStudents: statsData.favoriteTutorsCount || statsData.totalStudents || 0,
+          totalEarnings: statsData.totalEarnings || 0,
+          averageRating: parseFloat(statsData.averageRating) || 0,
+          hoursCompleted: statsData.hoursCompleted || 0,
         });
 
         // Recent Activity

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -86,11 +86,12 @@ const Dashboard = ({ currentUser }) => {
           hoursCompleted: statsData.hoursCompleted || 0,
         });
 
-        // Recent Activity
-        const mappedActivity = Array.isArray(data.recentActivity)
-          ? data.recentActivity.map(a => ({
-              id: a.date,
-              message: a.action,
+        // Recent Activity - handle both nested and direct structures
+        const activityData = data.recentActivity || [];
+        const mappedActivity = Array.isArray(activityData)
+          ? activityData.map(a => ({
+              id: a.date || a.id || Math.random(),
+              message: a.action || a.message || 'Activity',
               time: a.date ? new Date(a.date).toLocaleString() : '',
               icon: 'Calendar',
               status: a.status === 'pending' ? 'upcoming' : a.status
@@ -98,10 +99,11 @@ const Dashboard = ({ currentUser }) => {
           : [];
         setRecentActivity(mappedActivity);
 
-        // Upcoming Lessons - handle differently for tutors vs students
-        const mappedLessons = Array.isArray(data.upcomingLessons || data)
-          ? (data.upcomingLessons || data).map(l => ({
-              id: l._id || l.id || l.date,
+        // Upcoming Lessons - handle both nested and direct structures
+        const lessonsData = data.upcomingLessons || [];
+        const mappedLessons = Array.isArray(lessonsData)
+          ? lessonsData.map(l => ({
+              id: l._id || l.id || l.date || Math.random(),
               // For tutors, show student info; for students, show tutor info
               otherParty: currentUser.type === 'tutor'
                 ? (l.studentId?.fullName || l.student?.fullName || 'Unknown Student')

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -68,13 +68,18 @@ const Dashboard = ({ currentUser }) => {
         }
         const data = dashboardResponse.data || {};
 
+        // Show warning if using fallback data
+        if (dashboardResponse.fallback) {
+          console.warn('Using fallback dashboard data - API may not be returning data properly');
+        }
+
         // Stats
         setStats({
           totalBookings: data.stats?.totalBookings || 0,
           completedLessons: data.stats?.completedLessons || 0,
           totalSpent: data.stats?.totalSpent || 0,
           hoursLearned: data.stats?.hoursLearned || 0,
-          totalStudents: data.stats?.favoriteTutorsCount || 0,
+          totalStudents: data.stats?.favoriteTutorsCount || data.stats?.totalStudents || 0,
           totalEarnings: data.stats?.totalEarnings || 0,
           averageRating: data.stats?.averageRating || 0,
           hoursCompleted: data.stats?.hoursCompleted || 0,

--- a/src/lib/apiClient.js
+++ b/src/lib/apiClient.js
@@ -109,6 +109,9 @@ class ApiClient {
       }
 
       console.log('API response data:', data);
+      console.log('Response data type:', typeof data);
+      console.log('Response data keys:', data ? Object.keys(data) : 'No data');
+      console.log('Is data empty?', !data || Object.keys(data).length === 0);
 
       if (!response.ok) {
         console.error('API error response:', {

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -292,37 +292,72 @@ export const tutorAPI = {
     try {
       console.log('Fetching tutor dashboard stats...');
       const response = await apiClient.get('/tutors/dashboard/stats');
-      
+
+      console.log('Raw dashboard stats response:', response);
+      console.log('Response data:', JSON.stringify(response.data, null, 2));
+
       if (response.status === 'success') {
+        // Check if response.data is empty or undefined
+        if (!response.data || Object.keys(response.data).length === 0) {
+          console.warn('Dashboard stats API returned empty data, using fallback');
+          return {
+            success: true,
+            data: {
+              stats: {
+                totalBookings: 0,
+                upcomingLessons: 0,
+                totalEarnings: 0,
+                averageRating: 0,
+                totalStudents: 0,
+                hoursCompleted: 0
+              },
+              recentActivity: [],
+              upcomingLessons: []
+            },
+            fallback: true
+          };
+        }
+
         return {
           success: true,
           data: response.data
         };
       }
-      
+
+      console.warn('Dashboard stats API did not return success status, using fallback');
       return {
         success: true,
         data: {
-          totalBookings: 0,
-          upcomingLessons: 0,
-          totalEarnings: '0.00',
-          averageRating: 0,
-          totalStudents: 0,
-          hoursCompleted: 0
-        }
+          stats: {
+            totalBookings: 0,
+            upcomingLessons: 0,
+            totalEarnings: 0,
+            averageRating: 0,
+            totalStudents: 0,
+            hoursCompleted: 0
+          },
+          recentActivity: [],
+          upcomingLessons: []
+        },
+        fallback: true
       };
     } catch (error) {
       console.error('Error fetching tutor dashboard stats:', error);
       return {
         success: true,
         data: {
-          totalBookings: 0,
-          upcomingLessons: 0,
-          totalEarnings: '0.00',
-          averageRating: 0,
-          totalStudents: 0,
-          hoursCompleted: 0
-        }
+          stats: {
+            totalBookings: 0,
+            upcomingLessons: 0,
+            totalEarnings: 0,
+            averageRating: 0,
+            totalStudents: 0,
+            hoursCompleted: 0
+          },
+          recentActivity: [],
+          upcomingLessons: []
+        },
+        fallback: true
       };
     }
   },


### PR DESCRIPTION
## Purpose

The user was experiencing issues with tutor dashboard stats not displaying properly despite successful API responses. The conversation revealed that the dashboard stats API was returning data in a different structure than expected, and the user wanted to implement separate API endpoints for recent activity and upcoming lessons to improve data reliability.

## Code changes

- **Enhanced stats data handling**: Modified Dashboard.jsx to handle both nested (`data.stats.*`) and direct (`data.*`) API response structures
- **Added separate API calls for tutors**: Implemented dedicated calls to `/tutors/dashboard/activity` and `/tutors/dashboard/upcoming` endpoints for better data separation
- **Improved error handling**: Added fallback data structure and warning logs when API returns empty responses
- **Enhanced debugging**: Added comprehensive logging in apiClient.js to track response data structure and identify empty responses
- **Fixed data parsing**: Added proper parsing for averageRating and improved field mapping for both tutor and student dashboard views
- **Added fallback mechanism**: Implemented graceful degradation when API endpoints fail or return empty data

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/e952a104131744fda09f70d9c75b4540/mystic-landing)

👀 [Preview Link](https://e952a104131744fda09f70d9c75b4540-mystic-landing.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>e952a104131744fda09f70d9c75b4540</projectId>-->
<!--<branchName>mystic-landing</branchName>-->